### PR TITLE
Updated Jinja2 version to 2.10.1.

### DIFF
--- a/ts280_data_bridge/app/app/requirements.txt
+++ b/ts280_data_bridge/app/app/requirements.txt
@@ -5,7 +5,7 @@ curlify==2.0.1
 Flask==1.0.2
 idna==2.6
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==1.0
 requests==2.20.0
 urllib3==1.24.2


### PR DESCRIPTION
Jinja2 version updated because of an security alert.